### PR TITLE
Fix UserRefreshResponse and UserLoginResponse Model for API changes

### DIFF
--- a/FaloopIntegration/Faloop/FaloopSession.cs
+++ b/FaloopIntegration/Faloop/FaloopSession.cs
@@ -29,7 +29,7 @@ public class FaloopSession : IDisposable
             return false;
         }
 
-        var login = await client.LoginAsync(username, password, initialSession.SessionId, initialSession.Token);
+        var login = await client.LoginAsync(username, password, initialSession.Data.SessionId, initialSession.Data.Token);
         if (login is not {Success: true})
         {
             DalamudLog.Log.Debug("LoginAsync: login is not success");

--- a/FaloopIntegration/Faloop/FaloopSession.cs
+++ b/FaloopIntegration/Faloop/FaloopSession.cs
@@ -47,7 +47,7 @@ public class FaloopSession : IDisposable
         }
 
         IsLoggedIn = true;
-        SessionId = login.SessionId;
+        SessionId = login.Data.SessionId;
         return true;
     }
 

--- a/FaloopIntegration/Faloop/Model/UserLoginResponse.cs
+++ b/FaloopIntegration/Faloop/Model/UserLoginResponse.cs
@@ -1,8 +1,7 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace Divination.FaloopIntegration.Faloop.Model;
-
+namespace FaloopApi.Faloop.Model;
+public record LoginData(string SessionId, string Token);
 public record UserLoginResponse(
     [property: JsonPropertyName("success")] bool Success,
-    [property: JsonPropertyName("sessionId")] string SessionId,
-    [property: JsonPropertyName("token")] string Token);
+    [property: JsonPropertyName("data")] LoginData Data);

--- a/FaloopIntegration/Faloop/Model/UserLoginResponse.cs
+++ b/FaloopIntegration/Faloop/Model/UserLoginResponse.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace FaloopApi.Faloop.Model;
+namespace Divination.FaloopIntegration.Faloop.Model;
 public record LoginData(string SessionId, string Token);
 public record UserLoginResponse(
     [property: JsonPropertyName("success")] bool Success,

--- a/FaloopIntegration/Faloop/Model/UserRefreshResponse.cs
+++ b/FaloopIntegration/Faloop/Model/UserRefreshResponse.cs
@@ -1,3 +1,4 @@
 ﻿namespace Divination.FaloopIntegration.Faloop.Model;
 
-public record UserRefreshResponse(bool Success, string SessionId, string Token);
+public record UserData(string SessionId, string Token);
+public record UserRefreshResponse(bool Success, UserData Data);


### PR DESCRIPTION
The response of the refresh/login API endpoint changed.
Refresh:
```json
{
   "success":true,
   "data":{
      "sessionId":"SESSION_ID",
      "token":"TOKEN"
   }
}
```
Login:
```json
{
   "success":true,
   "data":{
      "sessionId":"SESSION_ID",
      "token":"TOKEN",
      "id":"ID",
      --Other data that isnt used in our case
    }
}
```

Changelog:
- adjusted UserRefreshResponse model
- adjusted UserLoginResponse model
- adjusted LoginAsync() to use the changed model data