### PR TITLE
add option for "simple" reports in chat

### DIFF
--- a/Divination.sln
+++ b/Divination.sln
@@ -2,7 +2,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # 
 VisualStudioVersion = 17.5.002.0
-MinimumVisualStudioVersion = 
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common", "Common\Common.csproj", "{C00AD6CE-4F53-4415-B105-183A7CD79FA7}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Calculator", "Calculator\Calculator.csproj", "{2CACF6DA-C279-4A07-AB7C-9AAC923FAADB}"

--- a/FaloopIntegration/Config/PluginConfig.cs
+++ b/FaloopIntegration/Config/PluginConfig.cs
@@ -28,6 +28,7 @@ public class PluginConfig : IPluginConfiguration
 
     public List<SpawnHistory> SpawnHistories = [];
     public bool EnableActiveMobUi = false;
+    public bool EnableSimpleReports = false;
 
     public class PerRankConfig
     {

--- a/FaloopIntegration/Config/PluginConfigWindow.cs
+++ b/FaloopIntegration/Config/PluginConfigWindow.cs
@@ -118,6 +118,8 @@ public class PluginConfigWindow : ConfigWindow<PluginConfig>
                 FaloopIntegration.Instance.Ui.IsDrawing = FaloopIntegration.Instance.Config.EnableActiveMobUi;
             }
 
+            ImGui.Checkbox(Localization.EnableSimpleReports, ref FaloopIntegration.Instance.Config.EnableSimpleReports);
+
             if (ImGui.Button("Emit mock payload"))
             {
                 FaloopIntegration.Instance.EmitMockData();

--- a/FaloopIntegration/FaloopIntegration.cs
+++ b/FaloopIntegration/FaloopIntegration.cs
@@ -161,11 +161,11 @@ public sealed class FaloopIntegration : DivinationPlugin<FaloopIntegration, Plug
             At = ev.Spawn.Timestamp,
         });
 
-        var payloads = new List<Payload>
-        {
-            Utils.GetRankIcon(ev.Rank),
-            new TextPayload($" {ev.Mob.Singular.RawString} "),
-        };
+        var payloads = new List<Payload>();
+        if (Config.EnableSimpleReports)
+            payloads.Add(new TextPayload($"{SeIconChar.BoxedPlus.ToIconString()}"));
+        payloads.Add(Utils.GetRankIcon(ev.Rank));
+        payloads.Add(new TextPayload($" {ev.Mob.Singular.RawString} "));
 
         var mapLink = CreateMapLink(ev.Spawn.ZoneId, ev.Spawn.ZonePoiIds.First(), ev.Data.ZoneInstance);
         if (mapLink != default)
@@ -173,11 +173,12 @@ public sealed class FaloopIntegration : DivinationPlugin<FaloopIntegration, Plug
             payloads.AddRange(mapLink.Payloads);
         }
 
-        payloads.AddRange(new Payload[]
-        {
-            new IconPayload(BitmapFontIcon.CrossWorld),
-            new TextPayload($"{ev.World.Name} {Localization.HasSpawned} {Utils.FormatTimeSpan(ev.Spawn.Timestamp)}".TrimEnd()),
-        });
+        payloads.Add(new IconPayload(BitmapFontIcon.CrossWorld));
+
+        if (Config.EnableSimpleReports)
+            payloads.Add(new TextPayload($"{ev.World.Name}".TrimEnd()));
+        else
+            payloads.Add(new TextPayload($"{ev.World.Name} {Localization.HasSpawned} {Utils.FormatTimeSpan(ev.Spawn.Timestamp)}".TrimEnd()));
 
         Dalamud.ChatGui.Print(new XivChatEntry
         {
@@ -197,16 +198,32 @@ public sealed class FaloopIntegration : DivinationPlugin<FaloopIntegration, Plug
             return;
         }
 
-        Dalamud.ChatGui.Print(new XivChatEntry
+        var payloads = new List<Payload>();
+        if (Config.EnableSimpleReports)
         {
-            Name = "Faloop",
-            Message = new SeString(new List<Payload>
+            payloads.AddRange(new Payload[]
+            {
+                new TextPayload($"{SeIconChar.Cross.ToIconString()}"),
+                new TextPayload($" {ev.Mob.Singular.RawString}"),
+                new IconPayload(BitmapFontIcon.CrossWorld),
+                new TextPayload($"{ev.World.Name}".TrimEnd()),
+            });
+        }
+        else
+        {
+            payloads.AddRange(new Payload[]
             {
                 Utils.GetRankIcon(ev.Rank),
                 new TextPayload($" {ev.Mob.Singular.RawString}"),
                 new IconPayload(BitmapFontIcon.CrossWorld),
                 new TextPayload($"{ev.World.Name} {Localization.WasKilled} {Utils.FormatTimeSpan(ev.Death.StartedAt)}".TrimEnd()),
-            }),
+            });
+        }
+
+        Dalamud.ChatGui.Print(new XivChatEntry
+        {
+            Name = "Faloop",
+            Message = new SeString(payloads),
             Type = Enum.GetValues<XivChatType>()[channel],
         });
     }

--- a/FaloopIntegration/Localization.cs
+++ b/FaloopIntegration/Localization.cs
@@ -195,4 +195,10 @@ public static class Localization
         En = "Enable Active Mobs UI",
         Ja = "「現在のモブ」パネルを表示",
     };
+
+    public static readonly LocalizedString EnableSimpleReports = new()
+    {
+        En = "Enable simplified, condensed reports in chat",
+        Ja = "",
+    };
 }


### PR DESCRIPTION
your solution file was broken and requires the min version in there to load properly

this toggleable option just removes the localised strings and timestamps from reports so that it's much more condensed. Spawn vs death is differentiated by a + and x icon respectively

also I do not speak japanese so the localisation on it is missing, sorry