### PR TITLE
added a teleport payload for quicker world travelling

### DIFF
--- a/FaloopIntegration/FaloopIntegration.cs
+++ b/FaloopIntegration/FaloopIntegration.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Dalamud.Divination.Common.Api.Dalamud;
+﻿using Dalamud.Divination.Common.Api.Dalamud;
 using Dalamud.Divination.Common.Api.Ui.Window;
 using Dalamud.Divination.Common.Boilerplate;
 using Dalamud.Divination.Common.Boilerplate.Features;
@@ -14,8 +10,13 @@ using Dalamud.Plugin;
 using Divination.FaloopIntegration.Config;
 using Divination.FaloopIntegration.Faloop;
 using Divination.FaloopIntegration.Faloop.Model;
+using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using Lumina.Excel.GeneratedSheets;
 using SocketIOClient;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Divination.FaloopIntegration;
 
@@ -148,7 +149,7 @@ public sealed class FaloopIntegration : DivinationPlugin<FaloopIntegration, Plug
         }
     }
 
-    private void OnMobSpawn(MobSpawnEvent ev, int channel)
+    private unsafe void OnMobSpawn(MobSpawnEvent ev, int channel)
     {
         Ui.OnMobSpawn(ev);
 
@@ -181,14 +182,11 @@ public sealed class FaloopIntegration : DivinationPlugin<FaloopIntegration, Plug
 
         payloads.Add(new IconPayload(BitmapFontIcon.CrossWorld));
 
-        if (Config.EnableSimpleReports)
-        {
-            payloads.Add(new TextPayload($"{ev.World.Name}".TrimEnd()));
-        }
-        else
-        {
-            payloads.Add(new TextPayload($"{ev.World.Name} {Localization.HasSpawned} {Utils.FormatTimeSpan(ev.Spawn.Timestamp)}".TrimEnd()));
-        }
+        payloads.Add(Dalamud.PluginInterface.AddChatLinkHandler((uint)ev.Spawn.Timestamp.ToFileTimeUtc(), (_, _) => { Telepo.Instance()->Teleport(Utils.GetStartTownAetheryte(), 0); }));
+        payloads.Add(new TextPayload($"{ev.World.Name}".TrimEnd()));
+        payloads.Add(RawPayload.LinkTerminator);
+        if (!Config.EnableSimpleReports)
+            payloads.Add(new TextPayload($" {Localization.HasSpawned} {Utils.FormatTimeSpan(ev.Spawn.Timestamp)}".TrimEnd()));
 
         Dalamud.ChatGui.Print(new XivChatEntry
         {

--- a/FaloopIntegration/FaloopIntegration.csproj
+++ b/FaloopIntegration/FaloopIntegration.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <RootNamespace>Divination.FaloopIntegration</RootNamespace>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>
@@ -9,6 +10,11 @@
 
         <Reference Include="Dalamud">
             <HintPath>$(DalamudLibPath)Dalamud.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+
+        <Reference Include="FFXIVClientStructs">
+            <HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="ImGui.NET">

--- a/FaloopIntegration/Utils.cs
+++ b/FaloopIntegration/Utils.cs
@@ -1,7 +1,10 @@
-﻿using System;
-using System.Text;
-using Dalamud.Game.Text;
+﻿using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
+using FFXIVClientStructs.FFXIV.Client.Game.UI;
+using Lumina.Excel.GeneratedSheets;
+using System;
+using System.Linq;
+using System.Text;
 
 namespace Divination.FaloopIntegration;
 
@@ -72,5 +75,11 @@ public static class Utils
 
         builder.Append(')');
         return builder.ToString();
+    }
+
+    public static unsafe uint GetStartTownAetheryte()
+    {
+        var starttown = FaloopIntegration.Instance.Dalamud.DataManager.GetExcelSheet<Town>()?.GetRow(UIState.Instance()->PlayerState.StartTown)?.Name.RawString ?? "null";
+        return FaloopIntegration.Instance.Dalamud.DataManager.GetExcelSheet<Aetheryte>()?.FirstOrDefault(a => a.PlaceName.Value!.Name.RawString.Contains(starttown))?.RowId ?? 0;
     }
 }


### PR DESCRIPTION
clicking the world text will take you to your starting city to quickly world travel

when [lifestream](https://github.com/NightmareXIV/Lifestream) gets updated with an IPC I can PR another change to this to have the payload do the entire tp to city -> world travel -> tp to zone with the mob, if the user has lifestream installed of course.

could just call it via chat command but that's clunky and adding support for that in `Common` is effort.