### PR TITLE
[FaloopIntegration] Remove SpawnRelease handler and fix SpawnState search logic.

### DIFF
--- a/FaloopIntegration/Faloop/Model/MobReportData.cs
+++ b/FaloopIntegration/Faloop/Model/MobReportData.cs
@@ -41,7 +41,6 @@ public static class MobReportActions
 {
     public const string Spawn = "spawn";
     public const string SpawnLocation = "spawn_location";
-    public const string SpawnRelease = "spawn_release";
     public const string SpawnFalse = "spawn_false";
     public const string Death = "death";
 }

--- a/FaloopIntegration/FaloopIntegration.cs
+++ b/FaloopIntegration/FaloopIntegration.cs
@@ -166,26 +166,16 @@ public sealed class FaloopIntegration : DivinationPlugin<FaloopIntegration, Plug
                         }
                     }
 
-                    var previous = Config.SpawnStates.FirstOrDefault(x => x.MobId == mobData.BNpcId && x.WorldId == worldId);
+                    var previous = Config.SpawnStates.FirstOrDefault(x =>
+                        x.MobId == mobData.BNpcId &&
+                        x.WorldId == worldId &&
+                        x.ZoneInstance == data.Ids.ZoneInstance);
                     if (previous == default)
                     {
                         DalamudLog.Log.Debug("OnMobReport: previous == null");
                         break;
                     }
                     var ev = new MobSpawnEvent(mobData.BNpcId, worldId, previous.TerritoryTypeId, data.Ids.ZoneInstance, mobData.Rank, previous?.SpawnedAt ?? DateTime.UtcNow, previous?.Reporter, location);
-                    OnMobSpawn(ev, config.Channel);
-                    break;
-                }
-            case MobReportActions.SpawnRelease when config.EnableSpawnReport:
-                {
-                    var spawn = JsonSerializer.Deserialize<MobReportData.SpawnRelease>(data.Data) ?? throw new InvalidOperationException("invalid spawn release data");
-                    var previous = Config.SpawnStates.FirstOrDefault(x => x.MobId == mobData.BNpcId && x.WorldId == worldId);
-                    if (previous == default)
-                    {
-                        DalamudLog.Log.Debug("OnMobReport: previous == null");
-                        break;
-                    }
-                    var ev = new MobSpawnEvent(mobData.BNpcId, worldId, previous.TerritoryTypeId, data.Ids.ZoneInstance, mobData.Rank, spawn.Timestamp, previous.Reporter, previous.Location);
                     OnMobSpawn(ev, config.Channel);
                     break;
                 }


### PR DESCRIPTION
`SpawnRelease` is only used by faloop to change the state of an report from scheduled to released.
The scheduled report comes as an `Spawn` action, meaning the plugin was announcing the report once for the Spawn action and again after the release for the `SpawnRelease` action, resulting an the same report being announced twice.

As for the `SpawnState`, the logic wasnt taking into consideration the instance, and sometimes when an Location update was triggered, it was grabbing some orphan state that matched it.
Its not an ideal solution tho, theres still room for mistakes but it should behave a bit better.

I was going to remove the persistence of SpawnStates in the config because i could not really find an reason for it to be persistent, but i decided to let the Author review it.
In my end, its usually a bunch of states that does not match the 1 hr deletion rule after an game restart and just sit there until next restart.