### PR TITLE
[AetheryteLinkInChat] Change links to be placed before message

### DIFF
--- a/AetheryteLinkInChat/AetheryteLinkInChat.cs
+++ b/AetheryteLinkInChat/AetheryteLinkInChat.cs
@@ -175,9 +175,13 @@ public class AetheryteLinkInChat : DivinationPlugin<AetheryteLinkInChat, PluginC
             if (Config.DisplayLineBreak)
             {
                 payloads.Insert(0, new TextPayload("\n"));
+                message.Payloads.AddRange(payloads);
             }
-
-            message.Payloads.AddRange(payloads);
+            else
+            {
+                var mapIndex = message.Payloads.FindIndex(p => p.GetType() == typeof(MapLinkPayload)) + 8;
+                message.Payloads.InsertRange(mapIndex, payloads);
+            }
         }
     }
 


### PR DESCRIPTION
Ive been using this for months now without any issues.
`var mapIndex = message.Payloads.FindIndex(p => p.GetType() == typeof(MapLinkPayload)) + 8;`
will find the index of the MapLink payload, the MapLink payload also uses 8 other payloads after it so we skip them too,
this index will land right before the message (if any) and we can use it to place the links in there.

(First message is with the line break option on)
![image](https://github.com/SlashNephy/Divination/assets/9062212/a76e35dd-6f51-4da9-9adb-b3f9010817de)
