### PR TITLE
[FaloopIntegration] Fix ActiveMobUi death function not being called.

### DIFF
--- a/FaloopIntegration/FaloopIntegration.cs
+++ b/FaloopIntegration/FaloopIntegration.cs
@@ -293,14 +293,14 @@ public sealed class FaloopIntegration : DivinationPlugin<FaloopIntegration, Plug
     {
         Ui.OnMobDeath(ev);
 
-        if (!enableDeathReport)
-        {
-            return;
-        }
-
         if (skipOrphanReport && spawnEvents.RemoveAll(x => x.Id == ev.Id) == 0)
         {
             DalamudLog.Log.Debug("OnDeathMobReport: skipOrphanReport");
+            return;
+        }
+
+        if (!enableDeathReport)
+        {
             return;
         }
 

--- a/FaloopIntegration/FaloopIntegration.cs
+++ b/FaloopIntegration/FaloopIntegration.cs
@@ -185,9 +185,10 @@ public sealed class FaloopIntegration : DivinationPlugin<FaloopIntegration, Plug
                     OnMobFalseSpawn(ev);
                     break;
                 }
-            case MobReportActions.Death when config.EnableDeathReport:
+            case MobReportActions.Death:
                 var death = JsonSerializer.Deserialize<MobReportData.Death>(data.Data) ?? throw new InvalidOperationException("invalid death data");
-                OnMobDeath(new MobDeathEvent(mobData.BNpcId, worldId, data.Ids.ZoneInstance, mobData.Rank, death.StartedAt), config.Channel, config.SkipOrphanReport);
+                OnMobDeath(new MobDeathEvent(mobData.BNpcId, worldId, data.Ids.ZoneInstance, mobData.Rank, death.StartedAt),
+                    config.Channel, config.SkipOrphanReport, config.EnableDeathReport);
                 DalamudLog.Log.Verbose("OnMobReport: OnDeathMobReport");
                 break;
         }
@@ -288,9 +289,14 @@ public sealed class FaloopIntegration : DivinationPlugin<FaloopIntegration, Plug
         spawnEvents.RemoveAll(x => x.Id == ev.Id);
     }
 
-    private void OnMobDeath(MobDeathEvent ev, int channel, bool skipOrphanReport)
+    private void OnMobDeath(MobDeathEvent ev, int channel, bool skipOrphanReport, bool enableDeathReport)
     {
         Ui.OnMobDeath(ev);
+
+        if (!enableDeathReport)
+        {
+            return;
+        }
 
         if (skipOrphanReport && spawnEvents.RemoveAll(x => x.Id == ev.Id) == 0)
         {


### PR DESCRIPTION
Fix #669 
The function to remove the report from the ActiveMobUi was behind the check for `Enable Mob Death Report`, causing it to only work properly when that setting was enabled, this should fix it.

Maybe would be a good idea to rewrite that switch logic into proper events that we can use to register handlers.