### PR TITLE
API 12  and .NET 9 Update

### DIFF
--- a/AetheryteLinkInChat.IpcModel/AetheryteLinkInChat.IpcModel.csproj
+++ b/AetheryteLinkInChat.IpcModel/AetheryteLinkInChat.IpcModel.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <RootNamespace>Divination.AetheryteLinkInChat.IpcModel</RootNamespace>
+        <TargetFramework>net9.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 </Project>

--- a/AetheryteLinkInChat.IpcModel/packages.lock.json
+++ b/AetheryteLinkInChat.IpcModel/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net8.0-windows7.0": {
+    "net9.0": {
       "GitVersion.MsBuild": {
         "type": "Direct",
         "requested": "[5.12.0, )",

--- a/AetheryteLinkInChat/AetheryteLinkInChat.csproj
+++ b/AetheryteLinkInChat/AetheryteLinkInChat.csproj
@@ -2,6 +2,8 @@
     <PropertyGroup>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <RootNamespace>Divination.AetheryteLinkInChat</RootNamespace>
+        <TargetFramework>net9.0-windows</TargetFramework>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -26,7 +28,7 @@
             <Private>False</Private>
         </Reference>
 
-        <PackageReference Include="DalamudPackager" Version="11.0.0">
+        <PackageReference Include="DalamudPackager" Version="12.0.0">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
 

--- a/AetheryteLinkInChat/packages.lock.json
+++ b/AetheryteLinkInChat/packages.lock.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
   "dependencies": {
-    "net8.0-windows7.0": {
+    "net9.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[11.0.0, )",
-        "resolved": "11.0.0",
-        "contentHash": "bjT7XUlhIJSmsE/O76b7weUX+evvGQctbQB8aKXt94o+oPWxHpCepxAGMs7Thow3AzCyqWs7cOpp9/2wcgRRQA=="
+        "requested": "[12.0.0, )",
+        "resolved": "12.0.0",
+        "contentHash": "J5TJLV3f16T/E2H2P17ClWjtfEBPpq3yxvqW46eN36JCm6wR+EaoaYkqG9Rm5sHqs3/nK/vKjWWyvEs/jhKoXw=="
       },
       "GitVersion.MsBuild": {
         "type": "Direct",

--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -10,6 +10,8 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <RootNamespace>Dalamud.Divination.Common</RootNamespace>
         <AssemblyName>Dalamud.Divination.Common</AssemblyName>
+        <TargetFramework>net9.0-windows</TargetFramework>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Common/packages.lock.json
+++ b/Common/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net8.0-windows7.0": {
+    "net9.0-windows7.0": {
       "GitVersion.MsBuild": {
         "type": "Direct",
         "requested": "[5.12.0, )",

--- a/FaloopIntegration/Faloop/FaloopSocketIOClient.cs
+++ b/FaloopIntegration/Faloop/FaloopSocketIOClient.cs
@@ -153,28 +153,25 @@ public class FaloopSocketIOClient : IDisposable
 
     private void HandleOnMessage(SocketIOResponse response)
     {
-        for (var index = 0; index < response.PacketId; index++)
+        var payload = response.GetValue<FaloopEventPayload>();
+        if (payload is not { Type: FaloopEventTypes.MobType, SubType: FaloopEventTypes.ReportSubType })
         {
-            var payload = response.GetValue<FaloopEventPayload>(index);
-            if (payload is not { Type: FaloopEventTypes.MobType, SubType: FaloopEventTypes.ReportSubType })
-            {
-                continue;
-            }
+            return;
+        }
 
-            var data = payload.Data.Deserialize<MobReportData>();
-            if (data == default)
-            {
-                continue;
-            }
+        var data = payload.Data.Deserialize<MobReportData>();
+        if (data == default)
+        {
+            return;
+        }
 
-            try
-            {
-                OnMobReport?.Invoke(data);
-            }
-            catch (Exception exception)
-            {
-                DalamudLog.Log.Error(exception, nameof(HandleOnMessage));
-            }
+        try
+        {
+            OnMobReport?.Invoke(data);
+        }
+        catch (Exception exception)
+        {
+            DalamudLog.Log.Error(exception, nameof(HandleOnMessage));
         }
 
         try

--- a/FaloopIntegration/Faloop/FaloopSocketIOClient.cs
+++ b/FaloopIntegration/Faloop/FaloopSocketIOClient.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Dalamud.Divination.Common.Api.Dalamud;
 using Divination.FaloopIntegration.Faloop.Model;
+using SocketIO.Core;
 using SocketIOClient;
 using SocketIOClient.Transport;
 
@@ -12,7 +13,7 @@ namespace Divination.FaloopIntegration.Faloop;
 // ReSharper disable once InconsistentNaming
 public class FaloopSocketIOClient : IDisposable
 {
-    private readonly SocketIO client = new("https://faloop.app",
+    private readonly SocketIOClient.SocketIO client = new("https://faloop.app",
         new SocketIOOptions
         {
             EIO = EngineIO.V4,
@@ -152,9 +153,9 @@ public class FaloopSocketIOClient : IDisposable
 
     private void HandleOnMessage(SocketIOResponse response)
     {
-        for (var index = 0; index < response.Count; index++)
+        for (var index = 0; index < response.PacketId; index++)
         {
-            var payload = response.GetValue(index).Deserialize<FaloopEventPayload>();
+            var payload = response.GetValue<FaloopEventPayload>(index);
             if (payload is not { Type: FaloopEventTypes.MobType, SubType: FaloopEventTypes.ReportSubType })
             {
                 continue;

--- a/FaloopIntegration/FaloopIntegration.cs
+++ b/FaloopIntegration/FaloopIntegration.cs
@@ -51,7 +51,7 @@ public sealed class FaloopIntegration : DivinationPlugin<FaloopIntegration, Plug
         socket.OnPing += OnPing;
         socket.OnPong += OnPong;
 
-        OnLogin();
+        Dalamud.Framework.RunOnFrameworkThread(OnLogin);
         Dalamud.ClientState.Login += OnLogin;
 
         var ipc = new AetheryteLinkInChatIpc(pluginInterface, Divination.Chat);

--- a/FaloopIntegration/FaloopIntegration.csproj
+++ b/FaloopIntegration/FaloopIntegration.csproj
@@ -3,6 +3,8 @@
         <RootNamespace>Divination.FaloopIntegration</RootNamespace>
         <UseWindowsForms>true</UseWindowsForms>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <TargetFramework>net9.0-windows</TargetFramework>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -30,9 +32,9 @@
             <HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>
             <Private>False</Private>
         </Reference>
-        <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
-        <PackageReference Include="SocketIOClient" Version="3.0.8" />
-        <PackageReference Include="DalamudPackager" Version="11.0.0">
+        <PackageReference Include="System.Net.Http.Json" Version="9.0.3" />
+        <PackageReference Include="SocketIOClient" Version="3.1.2" />
+        <PackageReference Include="DalamudPackager" Version="12.0.0">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <ProjectReference Include="..\Common\Common.csproj" />

--- a/FaloopIntegration/Ui/ActiveMobUi.cs
+++ b/FaloopIntegration/Ui/ActiveMobUi.cs
@@ -138,7 +138,7 @@ public class ActiveMobUi : IWindow, IDisposable
             return;
         }
 
-        agent->IsFlagMarkerSet = 0;
+        agent->IsFlagMarkerSet = false;
         agent->SetFlagMapMarker(mob.TerritoryTypeId, mob.Map.RowId, mob.WorldPosition.Value);
         Clipboard.SetText($"{text} <flag>");
     }

--- a/FaloopIntegration/packages.lock.json
+++ b/FaloopIntegration/packages.lock.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
   "dependencies": {
-    "net8.0-windows7.0": {
+    "net9.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[11.0.0, )",
-        "resolved": "11.0.0",
-        "contentHash": "bjT7XUlhIJSmsE/O76b7weUX+evvGQctbQB8aKXt94o+oPWxHpCepxAGMs7Thow3AzCyqWs7cOpp9/2wcgRRQA=="
+        "requested": "[12.0.0, )",
+        "resolved": "12.0.0",
+        "contentHash": "J5TJLV3f16T/E2H2P17ClWjtfEBPpq3yxvqW46eN36JCm6wR+EaoaYkqG9Rm5sHqs3/nK/vKjWWyvEs/jhKoXw=="
       },
       "GitVersion.MsBuild": {
         "type": "Direct",
@@ -16,50 +16,41 @@
       },
       "SocketIOClient": {
         "type": "Direct",
-        "requested": "[3.0.8, )",
-        "resolved": "3.0.8",
-        "contentHash": "uFpKuga3GEoWjJWGIkN00jeQu8XqQlWBVrigw0yKk9kkmPRWF2JlrrcT5/y4EK0cfKXu2yCdnECx+Y/zAXjRGA==",
+        "requested": "[3.1.2, )",
+        "resolved": "3.1.2",
+        "contentHash": "CMmnmhvG1Qf8k6BPh3RLqc/9MNvGUlCOyptjoP8a62bowPQkHTWvN25yy+gQqx5Ry/NgzkQHBJNpmRJhZNZrVQ==",
         "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Text.Json": "7.0.2"
+          "SocketIO.Serializer.Core": "3.1.2",
+          "SocketIO.Serializer.SystemTextJson": "3.1.2"
         }
       },
       "System.Net.Http.Json": {
         "type": "Direct",
-        "requested": "[8.0.0, )",
-        "resolved": "8.0.0",
-        "contentHash": "48Bxrd6zcGeQzS4GMEDVjuqCcAw/9wcEWnIu48FQJ5IzfKPiMR1nGtz9LrvGzU4+3TLbx/9FDlGmCUeLin1Eqg==",
+        "requested": "[9.0.3, )",
+        "resolved": "9.0.3",
+        "contentHash": "1PLQgaGNBaU6OYwXCcsvOncpayCaYy7gp2BsXrXHxQToKdTnLHHf5/MXyMf0nD6SfY9MMb/TC8HWR2weaNQctA=="
+      },
+      "SocketIO.Core": {
+        "type": "Transitive",
+        "resolved": "3.1.2",
+        "contentHash": "tb6vZ7DYhZooRGLHTPK7/Gifbu+kHbkQRbsee0LAnI28pWc5+Br+juh4pvid3kfIrGTl5dzAfy5huLELVU4svA=="
+      },
+      "SocketIO.Serializer.Core": {
+        "type": "Transitive",
+        "resolved": "3.1.2",
+        "contentHash": "/cJtU3JVzjqP/Jh3BpMMR0aNzYua6s9e3+hjZ6OnYprFHrGYyg/n9OcST1dBjmOvvgyJ3GwJlyq0NjnPETAHsA==",
         "dependencies": {
-          "System.Text.Json": "8.0.0"
+          "SocketIO.Core": "3.1.2"
         }
       },
-      "Microsoft.NETCore.Platforms": {
+      "SocketIO.Serializer.SystemTextJson": {
         "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
-      },
-      "Microsoft.NETCore.Targets": {
-        "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "aOZA3BWfz9RXjpzt0sRJJMjAscAUm3Hoa4UWAfceV9UTYxgwZ1lZt5nO2myFf+/jetYQo4uTP7zS8sJY67BBxg=="
-      },
-      "System.Collections": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "3Dcj85/TBdVpL5Zr+gEEBUuFe2icOnLalmEh9hfck1PTYbbyWuZgh4fmm2ysCLTrqLQw6t3TgTyJ+VLp+Qb+Lw==",
+        "resolved": "3.1.2",
+        "contentHash": "AA8w3Y4JldC3FaL1D4WuyG4zLPdrzjf8AQx1LCKtzlMlTLOcbEW0UGt+BhKxkUnxYAD5O5fsqRrTNCGXu6VeWA==",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Runtime": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "JufQi0vPQ0xGnAczR13AUFglDyVYt4Kqnz1AZaiKZ5+GICq0/1MH/mO/eAJHt/mHW1zjKBJd7kV26SrxddAhiw==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0"
+          "SocketIO.Core": "3.1.2",
+          "SocketIO.Serializer.Core": "3.1.2",
+          "System.Text.Json": "8.0.4"
         }
       },
       "System.Text.Encodings.Web": {
@@ -69,8 +60,8 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "OdrZO2WjkiEG6ajEFRABTRCi/wuXQPxeV6g8xvUJqdxMvvuCCEk86zPla8UiIQJz3durtUEbNyY/3lIhS0yZvQ==",
+        "resolved": "8.0.4",
+        "contentHash": "bAkhgDJ88XTsqczoxEMliSrpijKZHhbJQldhAmObj/RbrN3sU5dcokuXmWJWsdQAhiMJ9bTayWsL1C9fbbCRhw==",
         "dependencies": {
           "System.Text.Encodings.Web": "8.0.0"
         }


### PR DESCRIPTION
Update for API 12 and .NET 9.
I also updated `SocketIOClient` and `.Net.Http.Json`, the update on Socket client may fix some issues with transport close.
Still needs testing so leaving as a draft for now.

Had to remove the for loop from the MessageReceived Event Handler due to the `Count` field not being present anymore and i dont know how to handle that, i have never seen faloop send more than one report per message so it should be fine anyway.